### PR TITLE
fix: error when passing bufnr to popup.create()

### DIFF
--- a/lua/popup/init.lua
+++ b/lua/popup/init.lua
@@ -162,11 +162,17 @@ function popup.create(what, vim_options)
   -- maxwidth  Maximum width of the contents, excluding border, padding and scrollbar.
   -- minwidth  Minimum width of the contents, excluding border, padding and scrollbar.
   local width = vim_options.width or 1
-  for _, v in ipairs(what) do
-    width = math.max(width, #v)
+  local height
+  if type(what) == 'number' then
+    height = vim.api.nvim_buf_line_count(what)
+  else
+    for _, v in ipairs(what) do
+      width = math.max(width, #v)
+    end
+    height = #what
   end
   win_opts.width = utils.bounded(width, vim_options.minwidth, vim_options.maxwidth)
-  win_opts.height = utils.bounded(#what, vim_options.minheight, vim_options.maxheight)
+  win_opts.height = utils.bounded(height, vim_options.minheight, vim_options.maxheight)
 
   -- textprop, When present the popup is positioned next to a text
   -- ,   property with this name and will move when the text

--- a/lua/tests/basic_popup_spec.lua
+++ b/lua/tests/basic_popup_spec.lua
@@ -80,3 +80,13 @@ if test_level == 8 then
     -- border = { 1, 1, 1, 1 }
   })
 end
+
+if test_level == 9 then
+  local bufnr = vim.api.nvim_create_buf(false, false)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {'pass bufnr 1', 'pass bufnr 2'})
+  popup.create(bufnr, {
+    line = 8,
+    col = 55,
+    minwidth = 20,
+  })
+end


### PR DESCRIPTION
Hi.
I use it when I write popup scripts. Thank you very much 😍

I got an error when I passed the buffer number, so I fixed it.

`init.vim`

```vim
set encoding=utf-8

filetype plugin indent on
if has('vim_starting')
  let s:pluin_manager_dir='~/.config/nvim/.plugged/vim-plug'
  execute 'set runtimepath+=' . s:pluin_manager_dir
endif
call plug#begin('~/.config/nvim/.plugged')
Plug 'nvim-lua/popup.nvim'
Plug 'nvim-lua/plenary.nvim'
call plug#end()

language messages en_US.utf8

lua << EOF
local popup = require 'popup'

popup.create(vim.fn.bufnr(), {
    col = 1,
    line = 1,
    minwidth = 10,
    minheight = 10,
})
EOF
```


### Errors that occur

```vim
Error detected while processing /tmp/init.vim:
line   32:
E5108: Error executing lua ...o324/.config/nvim/.plugged/popup.nvim/lua/popup/init.lua:165: bad argument #1 to 'ipairs' (table expected, got number)
```


I hope you can merge them when you have time!
