### PR TITLE
callback support & fix border in cursor relative

### DIFF
--- a/lua/popup/init.lua
+++ b/lua/popup/init.lua
@@ -186,11 +186,7 @@ function popup.create(what, vim_options)
   if vim_options.hidden then
     assert(false, "I have not implemented this yet and don't know how")
   else
-    local should_enter = vim_options.enter
-    if should_enter == nil then
-      should_enter = true
-    end
-    win_id = vim.fn.nvim_open_win(bufnr, should_enter, win_opts)
+    win_id = vim.fn.nvim_open_win(bufnr, false, win_opts)
   end
 
 
@@ -331,6 +327,18 @@ function popup.create(what, vim_options)
 
   if vim_options.highlight then
     vim.api.nvim_win_set_option(win_id, 'winhl', string.format('Normal:%s', vim_options.highlight))
+  end
+
+  -- enter
+  local should_enter = vim_options.enter
+  if should_enter == nil then
+    should_enter = true
+  end
+
+  if should_enter then
+    -- set focus after border creation so that it's properly placed (especially
+    -- in relative cursor layout)
+    vim.api.nvim_set_current_win(win_id)
   end
 
   -- TODO: Perhaps there's a way to return an object that looks like a window id,

--- a/lua/tests/basic_popup_spec.lua
+++ b/lua/tests/basic_popup_spec.lua
@@ -2,7 +2,7 @@ require('plenary.reload').reload_module('popup')
 
 local popup = require('popup')
 
-local test_level = 3
+local test_level = 10
 
 vim.cmd [[highlight PopupColor1 ctermbg=lightblue guibg=lightblue]]
 vim.cmd [[highlight PopupColor2 ctermbg=lightcyan guibg=lightcyan]]
@@ -88,5 +88,16 @@ if test_level == 9 then
     line = 8,
     col = 55,
     minwidth = 20,
+  })
+end
+
+if test_level == 10 then
+  popup.create({ "option 1", "option 2" }, {
+    line = "cursor+2",
+    col = "cursor+2",
+	border = { 1, 1, 1, 1},
+	enter = true,
+	cursorline = true,
+	callback = function(win_id, sel) print(sel) end,
   })
 end


### PR DESCRIPTION
Hey @tjdevries,

Awesome that an effort is made to bring vim popup to Neovim.
I needed them (especially popup_menu) for another project.
This adds callbacks and also (maybe not sure?) fix borders when the popup has cursor relative positioning.

If the PR is accepted, I can burry my personal project [contextmenu.nvim](https://github.com/jbyuki/contextmenu.nvim) on it because it basically is identical.

Also, can I help out with the project (adds other options maybe?). Thanks.