### PR TITLE
Add `borderhighlight` option to compliment `highlight` option

### DIFF
--- a/lua/popup/init.lua
+++ b/lua/popup/init.lua
@@ -335,6 +335,10 @@ function popup.create(what, vim_options)
     vim.api.nvim_win_set_option(win_id, 'winhl', string.format('Normal:%s', vim_options.highlight))
   end
 
+  if vim_options.borderhighlight then
+    vim.api.nvim_win_set_option(border.win_id, 'winhl', string.format('Normal:%s', vim_options.borderhighlight))
+  end
+
   -- TODO: Perhaps there's a way to return an object that looks like a window id,
   --    but actually has some extra metadata about it.
   --


### PR DESCRIPTION
- [x] Add `borderhighlight` option to compliment `highlight` option. Example usage...

    ```lua
    local win_id, win = popup.create(bufnr, {
        highlight = 'HarpoonWindow',
        borderhighlight = 'HarpoonBorder',
        -- ...
    })
    ```