### PR TITLE
WIP: implement `zindex` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ this and wrap it with C functions to make the APIs compatible.
 
 ## List of Neovim Features Required:
 
-- [ ] Add Z-index for floating windows
-    - [ ] When complete, we can add `zindex` parameter
 - [ ] Key handlers (used for `popup_filter`)
 - [ ] scrollbar for floating windows
     - [ ] scrollbar
@@ -80,6 +78,7 @@ Suported Features:
     - [x] time
     - [x] title
     - [x] wrap
+    - [x] zindex
 
 ## All known unimplemented vim features at the moment
 

--- a/lua/popup/init.lua
+++ b/lua/popup/init.lua
@@ -89,7 +89,8 @@ function popup.create(what, vim_options)
   end
 
   local option_defaults = {
-    posinvert = true
+    posinvert = true,
+    zindex = 50,
   }
 
   local win_opts = {}
@@ -183,6 +184,11 @@ function popup.create(what, vim_options)
   -- related:
   --   textpropwin
   --   textpropid
+
+  -- zindex, Priority for the popup, default 50.  Minimum value is
+  -- ,   1, maximum value is 32000.
+  local zindex = dict_default(vim_options, 'zindex', option_defaults)
+  win_opts.zindex = utils.bounded(zindex, 1, 32000)
 
   local win_id
   if vim_options.hidden then


### PR DESCRIPTION
This implements the `zindex` option for the main window as done in vim, with hardcoded default, minimum and maximum values to match vim.

TODO:
- [ ] decide how best to handle `zindex` of the border (maybe 1 less than the `zindex` of the main? would then need to handle `zindex=1` as a special case)
- [ ] implement `zindex` for borders in plenary
- [ ] pass decided `zindex` option when creating the border