### PR TITLE
fixing title is not appear when it has no border

### DIFF
--- a/lua/popup/init.lua
+++ b/lua/popup/init.lua
@@ -339,6 +339,12 @@ function popup.create(what, vim_options)
   local border = nil
   if should_show_border then
     border = Border:new(bufnr, win_id, win_opts, border_options)
+  else
+    if vim_options.title then
+      border_options.top = ' '
+      border_options.border_thickness = {top=1, bot=0, right=0, left=0}
+      border = Border:new(bufnr, win_id, win_opts, border_options)
+    end
   end
 
   if vim_options.highlight then


### PR DESCRIPTION
Title is not showing when there's no border when creating popup. for example 
```
:lua require('popup').create({"Hello", "World"}, {title="Title", line="cursor+1", col="cursor+0", minwidth=25, minheight=15})
```
I found out that title is generated inside border top of plenary. So we need to create Border from plenary because we need the top part of the border, but still make all other side using thickness of 0.